### PR TITLE
Fix incorrect map size in FF/IE/Opera.

### DIFF
--- a/zipscribble.js
+++ b/zipscribble.js
@@ -75,8 +75,12 @@ function initMap(){
 
 	var po = org.polymaps;
 	
+	var svg = po.svg('svg');
+	svg.setAttribute('width', '100%');
+	svg.setAttribute('height', '100%');
+
 	map = po.map()
-	    .container(document.getElementById("map").appendChild(po.svg("svg")))
+	    .container(document.getElementById("map").appendChild(svg))
 	    .add(po.interact());
 	
 	mapLayer = po.image()


### PR DESCRIPTION
I fixed the bug where the [interactive zipscribble map doesn't fill the entire target div in non-Chrome browsers](http://eagereyes.org/zipscribble-maps/interactive-zipscribble-map#comment-5094) 

Based on: https://github.com/simplegeo/polymaps/issues/115#issuecomment-4553155
